### PR TITLE
TTV-102 Refactoring ExtensionStatemanager.ts / setDownloadPath & getDownloadPath

### DIFF
--- a/src/api/ExtensionStateManager.ts
+++ b/src/api/ExtensionStateManager.ts
@@ -26,24 +26,6 @@ export default class ExtensionStateManager {
     this.globalState = ctx.globalState
   }
 
-  // TODO: why is download path written in globalstate when it is defined in settings (from where it can be read from, too)
-
-  /**
-   * Sets the path for downloading tasks to the Global State.
-   * @param path - The path where the tasks will be downloaded.
-   */
-  static setDownloadPath(path: string) {
-    this.writeToGlobalState(StateKey.DownloadPath, path)
-  }
-
-  /**
-   * Retrieves the download path from the Global State.
-   * @returns The download path stored in the Global State.
-   */
-  static getDownloadPath(): string {
-    return this.readFromGlobalState(StateKey.DownloadPath)
-  }
-
   /**
    * Sets the courses data in the global state.
    * @param courses - An array containing the course data to be stored.
@@ -148,7 +130,6 @@ export default class ExtensionStateManager {
     this.writeToGlobalState(StateKey.Courses, undefined)
     this.writeToGlobalState(StateKey.LoginData, undefined)
     this.writeToGlobalState(StateKey.TaskPoints, undefined)
-    this.writeToGlobalState(StateKey.DownloadPath, undefined)
   }
 
   /**
@@ -259,10 +240,9 @@ interface NotifyFunction {
 }
 
 
-// type StateKey = 'courses' | 'downloadPath' | 'loginData' | 'taskPoints'
+// type StateKey = 'courses' | 'loginData' | 'taskPoints'
 export enum StateKey {
   Courses = 'courses',
-  DownloadPath = 'downloadPath',
   LoginData = 'loginData',
   TaskPoints = 'taskPoints'
 }

--- a/src/init/eventListeners.ts
+++ b/src/init/eventListeners.ts
@@ -46,19 +46,16 @@ export function registerEventListeners(ctx: vscode.ExtensionContext) {
   /**
    * Listens to changes in configuration.
    */
-  vscode.workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration('TIM-IDE.fileDownloadPath')) {
+  vscode.workspace.onDidChangeConfiguration((event) => 
+  {
+    if (event.affectsConfiguration('TIM-IDE.fileDownloadPath')) 
+    {
       // Get the new value of fileDownloadPath
-      const newPath = vscode.workspace.getConfiguration().get('TIM-IDE.fileDownloadPath')
-
-      // Update ExtensionStateManager with the new path
-      // TODO: Why is the download path stored in ExtensionStateManager when it is available in the settings?
-      if (typeof newPath === 'string') {
-        ExtensionStateManager.setDownloadPath(newPath)
-      } else {
-        // Handle invalid or undefined newPath
-        Logger.warning('Undefined download path')
+      const newPath = vscode.workspace.getConfiguration().get('TIM-IDE.fileDownloadPath');
+      if (typeof newPath !== 'string') 
+      {
+        Logger.warning('Undefined download path');
       }
     }
-  })
+  });
 }

--- a/src/ui/panels/CoursePanel.ts
+++ b/src/ui/panels/CoursePanel.ts
@@ -123,6 +123,7 @@ export default class CoursePanel {
           break
         }
         case 'SetDownloadPath': {
+          
           let newPath: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
             canSelectFiles: false,
             canSelectFolders: true,
@@ -131,7 +132,7 @@ export default class CoursePanel {
           })
           // If newPath is undefined or user cancels, get the previous path from global state
           if (!newPath) {
-            const previousPath = ExtensionStateManager.getDownloadPath()
+           const previousPath = vscode.workspace.getConfiguration().get<string>('TIM-IDE.fileDownloadPath', '');
             if (previousPath) {
               newPath = [vscode.Uri.file(previousPath)]
             }
@@ -203,7 +204,7 @@ export default class CoursePanel {
   private update() {
     const webview = this.panel.webview
     this.panel.webview.html = this.getHtmlForWebview(webview)
-    const path = ExtensionStateManager.getDownloadPath()
+    const path = vscode.workspace.getConfiguration().get('TIM-IDE.fileDownloadPath')
     this.sendInitialPath()
     this.panel.webview.postMessage({
       type: 'SetDownloadPathResult',


### PR DESCRIPTION
TTV-102 Refactored setDownloadpath/getDownloadPath in ExtensionStateManager.ts to use VS-Code settings directly instead of saving data in global state.

ExtensionStatemanager.ts  saves download path in global state, but already in many places the download patch is fetched directly with vscode.workspace.getConfiguration().get('TIM-IDE.fileDownloadPath') 

To make this more uniform, the directory is now fetched everywhere using this same method and setDownloadPath and getDownloadpath functions have been removed as they are no longer needed.
