### PR TITLE
TTV-118: Remove "Open in workspace" button

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -102,9 +102,11 @@ export default class Tide {
     const localCoursePath = path.join(path.normalize(downloadPathBase), courseName)
     const localTaskPath = path.join(path.normalize(downloadPathBase), courseName, taskName)
     this.runAndHandle(['task', 'create', taskSetPath, '-a', '-d', localCoursePath], (data: string) => {
-        ExtensionStateManager.setTaskSetDownloadPath(taskSetPath, localTaskPath)
-        /* Updating the tree view to reflect changes */
-        vscode.commands.executeCommand('tide.refreshTree') 
+    ExtensionStateManager.setTaskSetDownloadPath(taskSetPath, localTaskPath)
+    /* Updating the tree view to reflect changes */
+    vscode.commands.executeCommand('tide.refreshTree') 
+
+    
       // TODO: --json flag is not yet implemented in cli tool 
       // const taskCreationFeedback: TaskCreationFeedback = JSON.parse(data)
       // if (taskCreationFeedback.success) {

--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -103,6 +103,8 @@ export default class Tide {
     const localTaskPath = path.join(path.normalize(downloadPathBase), courseName, taskName)
     this.runAndHandle(['task', 'create', taskSetPath, '-a', '-d', localCoursePath], (data: string) => {
         ExtensionStateManager.setTaskSetDownloadPath(taskSetPath, localTaskPath)
+        /* Updating the tree view to reflect changes */
+        vscode.commands.executeCommand('tide.refreshTree') 
       // TODO: --json flag is not yet implemented in cli tool 
       // const taskCreationFeedback: TaskCreationFeedback = JSON.parse(data)
       // if (taskCreationFeedback.success) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -150,7 +150,6 @@ export type MessageType =
   | 'OnError'
   | 'OnInfo'
   | 'OpenSettings'
-  | 'OpenWorkspace'
   | 'RefreshCourseData'
   | 'RequestLoginData'
   | 'ResetExercise'
@@ -165,4 +164,3 @@ export type MessageType =
   | 'TaskPoints'
   | 'UpdateTaskPoints'
   | 'UpdateTimData'
-  | 'UpdateWorkspaceName'

--- a/src/ui/panels/CoursePanel.ts
+++ b/src/ui/panels/CoursePanel.ts
@@ -169,19 +169,6 @@ export default class CoursePanel {
           Tide.downloadTaskSet(taskSetPath)
           break
         }
-        case 'OpenWorkspace': {
-          const tasksetPath = msg.value;
-          //check that the local folder exists
-          if (!fs.existsSync(tasksetPath)) {
-            vscode.window.showErrorMessage(`Path does not exist: ${tasksetPath} \n Please download the taskset` );
-              this.panel.webview.postMessage({
-              type: 'WorkspaceError',
-            });
-            return;
-          }
-          vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(tasksetPath))
-          break
-        }
         case 'RequestLoginData': {
           this.sendLoginData(ExtensionStateManager.getLoginData())
           break

--- a/webviews/components/courses/TasksetTableRow.svelte
+++ b/webviews/components/courses/TasksetTableRow.svelte
@@ -29,7 +29,7 @@
   </td>
 {:else}
   <td colspan="2">Unavailable</td>
-0{/if}
+{/if}
 
 <style>
   td {

--- a/webviews/components/courses/TasksetTableRow.svelte
+++ b/webviews/components/courses/TasksetTableRow.svelte
@@ -25,13 +25,11 @@
   <td>{taskset.tasks.length}</td>
   <!-- <td>6/8</td> -->
   <td>
-    {#if taskset.downloadPath === undefined}
-      <button onclick={downloadTaskSet}>Download taskset</button>
-    {/if}
+    <button onclick={downloadTaskSet}>Download taskset</button>
   </td>
 {:else}
   <td colspan="2">Unavailable</td>
-{/if}
+0{/if}
 
 <style>
   td {

--- a/webviews/components/courses/TasksetTableRow.svelte
+++ b/webviews/components/courses/TasksetTableRow.svelte
@@ -17,23 +17,6 @@
       value: taskset.path,
     })
   }
-
-  /**
-   * Opens a workspace for the specified task set.
-   */
-  function openWorkspace() {
-    tsvscode.postMessage({
-      type: 'OpenWorkspace',
-      value: taskset.downloadPath,
-    })
-    window.addEventListener('message', (event) => {
-      const message = event.data;
-
-      if (message.type === 'WorkspaceError') {
-        taskset.downloadPath = undefined;
-      }
-    });
-  }
 </script>
 
 <td id="name-cell">{taskset.name}</td>
@@ -44,8 +27,6 @@
   <td>
     {#if taskset.downloadPath === undefined}
       <button onclick={downloadTaskSet}>Download taskset</button>
-    {:else}
-      <button onclick={openWorkspace}>Open in workspace</button>
     {/if}
   </td>
 {:else}

--- a/webviews/components/taskPanel/TaskPanel.svelte
+++ b/webviews/components/taskPanel/TaskPanel.svelte
@@ -31,7 +31,6 @@
     isLogged: false
   })
   let isLoggedIn = $state(false)
-  let workspace: string = $state('')
   let taskPoints: TaskPoints = $state({ current_points: undefined })
   let customUrl: string = $state('')
 
@@ -48,10 +47,6 @@
         }
         case 'LoginData': {
           loginData = message.value
-          break
-        }
-        case 'UpdateWorkspaceName': {
-          workspace = message.value
           break
         }
         case 'TaskPoints': {


### PR DESCRIPTION
The issue TTV-118, removal of "Open in workspace" button has been removed from this implementation along its earlier dependencies and related messaging systems.  The new UI logic has "Download taskset" button visible at all times, when the old logic included "Download taskset" button which changed into "Open in workspace button".  The new logic downloads the taskset and updates the treeview to reflect changes in directory structure.

The current logic has also been tested to work in case user removes task files manually. In case of manual file removal, clicking "Download taskset" will replace removed files but will keep previously edited files intact.
