### PR TITLE
Switch from undefined to null

### DIFF
--- a/webviews/components/taskPanel/PointsDisplay.svelte
+++ b/webviews/components/taskPanel/PointsDisplay.svelte
@@ -14,7 +14,7 @@
 A component for showing task points data.
 -->
 <div>
-  {#if taskPoints && taskPoints.current_points !== undefined && maxPoints !== null}
+  {#if taskPoints && taskPoints.current_points !== null && maxPoints !== null}
     <div id="points">
       <span>Task points</span>
       <span>{taskPoints.current_points} / {maxPoints}</span>

--- a/webviews/components/taskPanel/TaskPanel.svelte
+++ b/webviews/components/taskPanel/TaskPanel.svelte
@@ -31,7 +31,7 @@
     isLogged: false
   })
   let isLoggedIn = $state(false)
-  let taskPoints: TaskPoints = $state({ current_points: undefined })
+  let taskPoints: TaskPoints = $state({ current_points: null })
   let customUrl: string = $state('')
 
   /**


### PR DESCRIPTION
If user has not submitted tasks, current_points value is null and the task panel points display keeps loading. 

current_points value should be undefined, but is null:
Svelte reactively changes undefined to null, which causes issues. Change to use null instead of undefined.