### PR TITLE
[TTV-144]: Visual feedback through loading spinner attached to Download taskset-button

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -146,6 +146,7 @@ export type MessageType =
   | 'CourseData'
   | 'CustomUrl'
   | 'DownloadTaskSet'
+  | 'DownloadTaskSetComplete'
   | 'Login'
   | 'LoginData'
   | 'Logout'

--- a/src/ui/panels/CoursePanel.ts
+++ b/src/ui/panels/CoursePanel.ts
@@ -192,6 +192,11 @@ export default class CoursePanel {
 
             // Refresh TreeView with the new data
             vscode.commands.executeCommand('tide.refreshTree')
+            this.panel.webview.postMessage({
+              type: 'DownloadTaskSetComplete',
+              value: taskSetPath,
+            })
+
 
           } catch (error) {
             console.log('Downloading a new taskset had an error: ' + error)

--- a/webviews/components/common/LoaderButton.svelte
+++ b/webviews/components/common/LoaderButton.svelte
@@ -36,9 +36,6 @@
     cursor: pointer;
     transition: background 0.3s;
     border-radius: 3px;
-    position: absolute;
-    top: 10%;
-    right: 16%;
   }
 
   .loader-button:hover {
@@ -47,14 +44,6 @@
 
   .loader-button.loading {
     background-color: 005F9E;
-  }
-
-  @media (max-width: 512px) {
-    .loader-button {
-      position: relative;  
-      top: auto; 
-      right: auto;
-    }
   }
 
 </style>

--- a/webviews/components/courses/Courses.svelte
+++ b/webviews/components/courses/Courses.svelte
@@ -91,12 +91,14 @@ updates the courses' status, and handles downloading task sets and opening works
 
 {#if isLoggedIn}
   <div>
-    <LoaderButton
-      text="Refresh"
-      textWhileLoading="Refreshing"
-      loading={coursesRefreshing}
-      onClick={refreshCourses}
-    />
+    <div class="refresh-button">
+        <LoaderButton
+        text="Refresh"
+        textWhileLoading="Refreshing"
+        loading={coursesRefreshing}
+        onClick={refreshCourses}
+        />
+    </div>
   </div>
 
   {#if downloadPath === null}
@@ -142,5 +144,10 @@ updates the courses' status, and handles downloading task sets and opening works
   h1 {
     margin-bottom: 2rem;
     font-size: 2rem;
+  }
+  .refresh-button {
+    position: absolute;
+    top: 10%;
+    right: 16%;
   }
 </style>

--- a/webviews/components/courses/TasksetTableRow.svelte
+++ b/webviews/components/courses/TasksetTableRow.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import type { TaskSet } from '../../../src/common/types'
+  import { onMount } from 'svelte'
+  import type { TaskSet, WebviewMessage } from '../../../src/common/types'
+
+  import LoaderButton from '../common/LoaderButton.svelte'
 
   interface Props {
     taskset: TaskSet;
@@ -8,10 +11,33 @@
 
   let { taskset, isLoggedIn }: Props = $props();
 
+  let downloadingTasks: boolean = $state(false)
+  
+  /* 
+   * Listens for messages from CoursePanel.ts.
+   */
+  onMount(() => 
+  {
+    window.addEventListener('message', (event) => 
+    {
+      const message: WebviewMessage = event.data
+      switch (message.type) 
+      {
+        case 'DownloadTaskSetComplete': 
+        {
+            downloadingTasks = false
+            break
+        }
+      }
+    })
+  })
+
+
   /**
    * Initiates the download of a task set identified by its path.
    */
   function downloadTaskSet() {
+    downloadingTasks = true
     tsvscode.postMessage({
       type: 'DownloadTaskSet',
       value: taskset.path,
@@ -25,7 +51,7 @@
   <td>{taskset.tasks.length}</td>
   <!-- <td>6/8</td> -->
   <td>
-    <button onclick={downloadTaskSet}>Download taskset</button>
+    <LoaderButton loading={downloadingTasks} text="Download taskset" textWhileLoading="Downloading..." onClick={downloadTaskSet} />
   </td>
 {:else}
   <td colspan="2">Unavailable</td>
@@ -42,17 +68,4 @@
     text-align: left;
   }
 
-  button {
-    background-color:rgb(0, 111, 185);
-    color: white;
-    border: none;
-    padding: 5px;
-    cursor: pointer;
-    transition: background 0.3s;
-    border-radius: 3px;
-  }
-
-  button:hover {
-    background-color:rgb(0, 83, 138);
-  }
 </style>


### PR DESCRIPTION
Loading spinner has been attached to the Download taskset-button. Additionally, noticed that LoaderButton-component also has stylistic absolute settings that dictates its location. These positional CSS settings have been thrown away to make the component reusable. Refresh-button on the course page has now its own stylistic settings to reposition it to where it was before.
