### PR TITLE
Ttv 18 check login

### DIFF
--- a/src/api/ExtensionStateManager.ts
+++ b/src/api/ExtensionStateManager.ts
@@ -13,7 +13,7 @@
 
 import * as vscode from 'vscode'
 import Logger from '../utilities/logger'
-import { Course, CourseStatus, LoginData, TaskPoints, TimData } from '../common/types'
+import { Course, CourseStatus, LoginData, TaskPoints, TimData, UserData } from '../common/types'
 import path from 'path'
 import * as fs from 'fs'
 
@@ -62,6 +62,22 @@ export default class ExtensionStateManager {
    */
   public static getLoginData(): LoginData {
     return this.readFromGlobalState(StateKey.LoginData)
+  }
+
+  /**
+   * Sets user data to global state
+   * @param loggedInUserData UserData saved to the global state
+   */
+  public static setUserData(loggedInUserData: UserData) {
+    this.writeToGlobalState(StateKey.UserData, loggedInUserData)
+  }
+
+  /**
+   * Retrieves user data from global state
+   * @returns User Data saved to the global state
+   */
+  public static getUserData(): UserData {
+    return this.readFromGlobalState(StateKey.UserData)
   }
 
   /**
@@ -378,6 +394,7 @@ export enum StateKey {
   Courses = 'courses',
   DownloadPath = 'downloadPath',
   LoginData = 'loginData',
+  UserData = 'userData',
   TaskPoints = 'taskPoints',
   TimData = 'timData'
 }

--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -10,7 +10,7 @@
 import * as cp from 'child_process'
 import Logger from '../utilities/logger'
 import * as vscode from 'vscode'
-import { Course, LoginData, Task, TaskCreationFeedback, TaskPoints } from '../common/types'
+import { Course, LoginData, Task, TaskCreationFeedback, TaskPoints, UserData } from '../common/types'
 import { parseCoursesFromJson } from '../utilities/parsers'
 import ExtensionStateManager from './ExtensionStateManager'
 import path from 'path'
@@ -49,6 +49,26 @@ export default class Tide {
       Logger.info(`Logout: ${data}`)
     })
     return { isLogged: false }
+  }
+
+  /**
+   * Executes tide check-login command.
+   * @returns Logged in user data as JSON
+   */
+  public static async checkLogin(): Promise<UserData> {
+    let loggedInUserData: UserData = { logged_in: null}
+    await this.runAndHandle(['check-login', '--json'], (data: string) => {
+      Logger.info(`Login data: ${data}`)
+      loggedInUserData = JSON.parse(data)
+      if (loggedInUserData.logged_in) {
+          ExtensionStateManager.setLoginData({isLogged: true})
+          ExtensionStateManager.setUserData(loggedInUserData)
+        } else {
+          ExtensionStateManager.setLoginData({isLogged: false})
+          ExtensionStateManager.setUserData(loggedInUserData)
+        }
+    })
+    return loggedInUserData
   }
 
   /**

--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -60,13 +60,6 @@ export default class Tide {
     await this.runAndHandle(['check-login', '--json'], (data: string) => {
       Logger.info(`Login data: ${data}`)
       loggedInUserData = JSON.parse(data)
-      if (loggedInUserData.logged_in) {
-          ExtensionStateManager.setLoginData({isLogged: true})
-          ExtensionStateManager.setUserData(loggedInUserData)
-        } else {
-          ExtensionStateManager.setLoginData({isLogged: false})
-          ExtensionStateManager.setUserData(loggedInUserData)
-        }
     })
     return loggedInUserData
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -121,6 +121,13 @@ export interface LoginData {
   isLogged: boolean
 }
 
+/**
+ * Username of the logged in user, null when logged out
+ */
+export interface UserData {
+  logged_in: string | null
+}
+
 export interface TaskPoints {
   current_points: number | undefined
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,9 +18,10 @@ import ExtensionStateManager from './api/ExtensionStateManager'
 import UiController from './ui/UiController'
 import { CourseTaskProvider } from './ui/panels/TaskExplorerProvider'
 import { TaskPanelProvider } from './ui/panels/TaskPanelProvider'
+import Tide from './api/tide'
 
 // This method is called when your extension is activated
-export function activate(ctx: vscode.ExtensionContext) {
+export async function activate(ctx: vscode.ExtensionContext) {
   Logger.init('TIDE Logs')
   Logger.show()
   ExtensionStateManager.setContext(ctx)
@@ -29,6 +30,20 @@ export function activate(ctx: vscode.ExtensionContext) {
   init.registerEventListeners(ctx)
 
   // vscode.commands.executeCommand('tide.updateCoursesFromTim')
+
+  // Initialize Login and User Data
+  const userData = await Tide.checkLogin()
+  if (userData.logged_in) {
+            ExtensionStateManager.setLoginData({isLogged: true})
+            ExtensionStateManager.setUserData(userData)
+          } else {
+            ExtensionStateManager.setLoginData({isLogged: false})
+            ExtensionStateManager.setUserData(userData)
+          }
+  console.log(userData)
+  
+
+
 
   // Creates and registers the side menu on the left
   const sidebarProvider = new SidebarProvider(ctx.extensionUri)

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -113,8 +113,10 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
    */
   ctx.subscriptions.push(
     vscode.commands.registerCommand('tide.login', async () => {
-      let data = await Tide.login()
-      ExtensionStateManager.setLoginData(data)
+      let loginData = await Tide.login()
+      ExtensionStateManager.setLoginData(loginData)
+      let userData = await Tide.checkLogin()
+      ExtensionStateManager.setUserData(userData)
     }),
   )
 
@@ -125,6 +127,8 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tide.logout', async () => {
       let data = await Tide.logout()
       ExtensionStateManager.setLoginData(data)
+      let userData = await Tide.checkLogin()
+      ExtensionStateManager.setUserData(userData)
     }),
   )
 

--- a/src/ui/panels/SidebarProvider.ts
+++ b/src/ui/panels/SidebarProvider.ts
@@ -11,7 +11,6 @@ import * as vscode from 'vscode'
 import ExtensionStateManager, {StateKey} from '../../api/ExtensionStateManager'
 import { LoginData, MessageType, WebviewMessage } from '../../common/types'
 import { getDefaultHtmlForWebview } from '../utils'
-import Logger from '../../utilities/logger'
 import UiController from '../UiController'
 
 export class SidebarProvider implements vscode.WebviewViewProvider {

--- a/src/ui/panels/TaskExplorerProvider.ts
+++ b/src/ui/panels/TaskExplorerProvider.ts
@@ -26,6 +26,7 @@ export class CourseTaskProvider implements vscode.TreeDataProvider<CourseTaskTre
 
         // Context menu commands (right-click menu)
         vscode.commands.registerCommand('tide.treeviewMenuOpenTasks', item => this.openTasksInThisDir(item))
+
     }
 
     // Empty treeview and close files after a user logs out


### PR DESCRIPTION
Added tide-cli check-login usage to tide-vscode.
Extension now checks the login state when opened and sets the extension data to match.
UserData can now be stored and used. (username)
Also fixed the problem when trying to login when already logged in and tide-cli doesn't return json data but a string. (even tho this should never happen again with the implementation of check-login)