### PR TITLE
fix TaskPoints type field current_points to accept null

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -131,7 +131,7 @@ export interface UserData {
 }
 
 export interface TaskPoints {
-  current_points: number | undefined
+  current_points: number | null
 }
 
 export interface TaskCreationFeedback {


### PR DESCRIPTION
The TaskPanel.svelte taskPoints has state containing a reference to current_points with a type null.
This pull request changes the type TaskPoints field current_points to accept number or null instead of previous undefined.

This change removes the type error in TaskPanel.svelte.