### PR TITLE
Fallback value for customUrl

### DIFF
--- a/src/ui/panels/CoursePanel.ts
+++ b/src/ui/panels/CoursePanel.ts
@@ -78,12 +78,16 @@ export default class CoursePanel {
   }
 
   /**
-   * Sends user defined url for the tim instance address from the settings
+   * Sends user defined url for the tim instance address from the settings.
+   * Use default address "https://tim.jyu.fi/", if customUrl is empty
    * The intended recepient is Courses.svelte.
    * @param customUrl 
    */
   private sendCustomUrl() {
-    const customUrl = vscode.workspace.getConfiguration().get("TIM-IDE.customUrl")
+    let customUrl = vscode.workspace.getConfiguration().get("TIM-IDE.customUrl")
+    if (!customUrl) {
+      customUrl = "https://tim.jyu.fi/";
+    }
     const msg: WebviewMessage = {
       type: "CustomUrl",
       value: customUrl,

--- a/src/ui/panels/TaskPanelProvider.ts
+++ b/src/ui/panels/TaskPanelProvider.ts
@@ -93,9 +93,13 @@ export class TaskPanelProvider implements vscode.WebviewViewProvider {
 
     /**
      * Sends custom Url from the settings
+     * Use default address "https://tim.jyu.fi/", if customUrl is empty
      */
     private sendCustomUrl() {
-        const customUrl = vscode.workspace.getConfiguration().get("TIM-IDE.customUrl")
+        let customUrl = vscode.workspace.getConfiguration().get("TIM-IDE.customUrl")
+        if (!customUrl) {
+            customUrl = "https://tim.jyu.fi/";
+        }
         this._view?.webview.postMessage({ type: "CustomUrl", value: customUrl})
         console.log(customUrl)
     }


### PR DESCRIPTION
Addressing issue, where links 'Open exercise in TIM' and 'Open material page' don't work, if custom Url value in plugin settings is empty. 

Makes customUrl update to value 'https:/tim.jyu.fi', if the field for customUrl in settings is empty.