### PR TITLE
TTV-82 warn the user that current task has set answer limit

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,6 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   // Creates and registers taskbar item for displaying answer_limit warnings
   const answerLimitStatusBarItem = new AnswerLimitStatusBarItem(vscode.StatusBarAlignment.Right, 500)
-  answerLimitStatusBarItem.show()
   ctx.subscriptions.push(answerLimitStatusBarItem)
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import UiController from './ui/UiController'
 import { CourseTaskProvider } from './ui/panels/TaskExplorerProvider'
 import { TaskPanelProvider } from './ui/panels/TaskPanelProvider'
 import Tide from './api/tide'
+import AnswerLimitStatusBarItem from './ui/AnswerLimitStatusBarItem'
 
 // This method is called when your extension is activated
 export async function activate(ctx: vscode.ExtensionContext) {
@@ -59,6 +60,11 @@ export async function activate(ctx: vscode.ExtensionContext) {
   // Creates and registers the taskpanel menu on the left
   const taskPanelProvider = new TaskPanelProvider(ctx.extensionUri)
   ctx.subscriptions.push(vscode.window.registerWebviewViewProvider('tide-taskpanel', taskPanelProvider))
+
+  // Creates and registers taskbar item for displaying answer_limit warnings
+  const answerLimitStatusBarItem = new AnswerLimitStatusBarItem(vscode.StatusBarAlignment.Right, 500)
+  answerLimitStatusBarItem.show()
+  ctx.subscriptions.push(answerLimitStatusBarItem)
 }
 
 // This method is called when your extension is deactivated

--- a/src/ui/AnswerLimitStatusBarItem.ts
+++ b/src/ui/AnswerLimitStatusBarItem.ts
@@ -1,13 +1,12 @@
-/**
- * Class for Status Bar item displaying answer limit related information
- * to users when loading tasks that have set answer_limit value in TIM.
- */
-
 import * as vscode from 'vscode'
 import { TimData } from '../common/types'
 import path from 'path'
 import ExtensionStateManager from '../api/ExtensionStateManager'
 
+/**
+ * Class for Status Bar item displaying answer limit related information
+ * to users when loading tasks that have set answer_limit value in TIM.
+ */
 export default class AnswerLimitStatusBarItem {
     readonly name: string = 'Answer limit for current task'
     readonly text: string = `$(alert) Limited number of submissions allowed`

--- a/src/ui/AnswerLimitStatusBarItem.ts
+++ b/src/ui/AnswerLimitStatusBarItem.ts
@@ -32,7 +32,7 @@ export default class AnswerLimitStatusBarItem {
             AnswerLimitStatusBarItem.activeEditor = editor
             if (editor) {
                 const timData = await this.getTimData()
-                console.log(editor)
+                timData?.answer_limit ? this.statusBarItem.show() : this.statusBarItem.hide()
             }
         })
     }

--- a/src/ui/AnswerLimitStatusBarItem.ts
+++ b/src/ui/AnswerLimitStatusBarItem.ts
@@ -11,9 +11,8 @@ import ExtensionStateManager from '../api/ExtensionStateManager'
 export default class AnswerLimitStatusBarItem {
     readonly name: string = 'Answer limit for current task'
     readonly text: string = `$(alert) Limited number of submissions allowed`
-    readonly tooltip: string =  `This task can only be submitted to TIM a limited number of times. 
-    After all tries have run out, you can no longer get more by submitting the answer to TIM.
-    Check TIM task page to see how many attempts have been used.`
+    private answerLimit?: number | null
+    readonly tooltip: string = `This task can only be submitted to TIM a limited number of times.\nAfter all tries have run out, you can no longer get more points by\nsubmitting the answer to TIM.\nCheck TIM task page to see how many attempts have been used.`
     private statusBarItem: vscode.StatusBarItem
     private static activeEditor?: vscode.TextEditor
 
@@ -33,6 +32,8 @@ export default class AnswerLimitStatusBarItem {
             if (editor) {
                 const timData = await this.getTimData()
                 timData?.answer_limit ? this.statusBarItem.show() : this.statusBarItem.hide()
+                this.answerLimit = timData?.answer_limit
+                this.statusBarItem.tooltip = this.tooltip + `\nThis exercise has limit of ${this.answerLimit} submissions.`
             }
         })
     }

--- a/src/ui/AnswerLimitStatusBarItem.ts
+++ b/src/ui/AnswerLimitStatusBarItem.ts
@@ -1,0 +1,76 @@
+/**
+ * Class for Status Bar item displaying answer limit related information
+ * to users when loading tasks that have set answer_limit value in TIM.
+ */
+
+import * as vscode from 'vscode'
+import { TimData } from '../common/types'
+import path from 'path'
+import ExtensionStateManager from '../api/ExtensionStateManager'
+
+export default class AnswerLimitStatusBarItem {
+    readonly name: string = 'Answer limit for current task'
+    readonly text: string = `$(alert) Limited number of submissions allowed`
+    readonly tooltip: string =  `This task can only be submitted to TIM a limited number of times. 
+    After all tries have run out, you can no longer get more by submitting the answer to TIM.
+    Check TIM task page to see how many attempts have been used.`
+    private statusBarItem: vscode.StatusBarItem
+    private static activeEditor?: vscode.TextEditor
+
+    constructor(alignment: vscode.StatusBarAlignment, priority: number) {
+        this.statusBarItem = vscode.window.createStatusBarItem(alignment, priority)
+        this.statusBarItem.text = this.text
+        this.statusBarItem.name = this.name
+        this.statusBarItem.tooltip = this.tooltip
+        this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+
+        /**
+         * Event listener for determining whether to display answer limit warning
+         * based on timdata. This segment is adapted from TaskPanelProvider.ts
+         */
+        vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+            AnswerLimitStatusBarItem.activeEditor = editor
+            if (editor) {
+                const timData = await this.getTimData()
+                console.log(editor)
+            }
+        })
+    }
+
+    show(): void {
+        this.statusBarItem.show()
+    }
+    hide(): void {
+        this.statusBarItem.hide()
+    }
+    dispose(): void {
+        this.statusBarItem.dispose()
+    }
+
+    // The following is taken from TaskPanelProvider.ts - Possible refactoring needed
+    /**
+    * Retrieves TIM data for the active text editor.
+    */
+    private async getTimData(): Promise<TimData | undefined> {
+        if (!AnswerLimitStatusBarItem.activeEditor) return undefined;
+
+        try {
+            const doc = AnswerLimitStatusBarItem.activeEditor.document
+            const currentDir = path.dirname(doc.fileName)
+            // Find the names of the tasks ide_task_id and the task set from the files path
+            let itemPath = currentDir
+            // console.log(path)
+            let pathSplit = itemPath.split(path.sep)
+            // ide_task_id
+            let id = pathSplit.at(-1)
+            // task set name
+            let demo = pathSplit.at(-2)
+            if (demo && id) {
+                return (ExtensionStateManager.getTaskTimData(demo, id))
+            }
+        } catch {
+            return undefined
+        }
+    }
+
+}


### PR DESCRIPTION
This is a proposal to add a new feature to the Extension. This pull request introduces a warning item to the statusBar, that warns the user that currently opened task has a set limit for number of submissions accepted. 

The answerLimitStatusBarItem is displayed to user when timdata has set answer_limit field. In this implementation, there is also a tooltip text, that displays the answer limit as a part of the warning text.

This implementation uses parts of TaskPanelProvider for timdata retrieval. In future, it could be good idea to refactor the timdata retrieval to a common module.