### PR TITLE
Ttv 155 save dialog in submit

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -169,7 +169,7 @@ export default class Tide {
    */
   public static async submitTask(taskPath: string, callback: () => any) {
     this.runAndHandle(['submit', taskPath], (data: string) => {
-      Logger.debug(data)
+      Logger.info(data)
       const course: Course =  ExtensionStateManager.getCourseByDownloadPath(path.dirname(path.dirname(taskPath)))
       const taskset = course.taskSets.find(taskSet => taskSet.downloadPath === path.dirname(path.dirname(taskPath)))
       const currentDir = path.dirname(taskPath)

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -99,7 +99,7 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
         return;
       }
       const taskPath = editor.document.uri.fsPath;
-      const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
+      const callback = () => vscode.window.showInformationMessage('Task was submitted to TIM');
       
       // If changes, check if user wants to save and submit task to TIM
       if (editor.document.isDirty) {

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -99,6 +99,7 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
         return;
       }
       const taskPath = editor.document.uri.fsPath;
+      const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
       
       // If changes, check if user wants to save and submit task to TIM
       if (editor.document.isDirty) {
@@ -115,13 +116,12 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
           messageOpts,
           ...modalOpts
         )
-        
+        // Cancel
         if (!selection) {
           return
         }
 
         if (selection === 'Submit without Saving') {
-          const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
           Tide.submitTask(taskPath, callback) 
         }
         else {
@@ -131,15 +131,13 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
               vscode.window.showErrorMessage('Save failed - Current task has not been submitted!')
               return
             }
-            const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
             Tide.submitTask(taskPath, callback)
           } catch (error) {
-            vscode.window.showErrorMessage('Error occurred during the submission: ${error}')
+            vscode.window.showErrorMessage('Error occurred during the submit: ${error}')
           }
         }
       }
       else {
-        const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
         Tide.submitTask(taskPath, callback)
       }
     }),

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -99,9 +99,30 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
         return;
       }
       const taskPath = editor.document.uri.fsPath;
+      
+      // If changes, check if user wants to save and submit task to TIM
+      if (editor.document.isDirty) {
+        const messageOpts: vscode.MessageOptions = {
+          "detail": "Only the most recent saved file is submitted to TIM.",
+          "modal": true
+        }
+        const modalOpts: string[] = [
+          'Continue without saving'
+        ]
+        vscode.window.showInformationMessage(
+          'Unsaved Changes in Current File',
+          messageOpts,
+          ...modalOpts
+        ).then((answer) => {
+          if (answer === 'Cancel') {
+            return;
+          }
+        })
+      }
+      
       // TODO: callback should maybe be a show output function
       const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
-      Tide.submitTask(taskPath, callback)
+      Tide.submitTask(taskPath, callback) 
     }),
   )
 

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -103,26 +103,35 @@ export function registerCommands(ctx: vscode.ExtensionContext) {
       // If changes, check if user wants to save and submit task to TIM
       if (editor.document.isDirty) {
         const messageOpts: vscode.MessageOptions = {
-          "detail": "Only the most recent saved file is submitted to TIM.",
+          "detail": "Do you wish to save the changes before submitting the task to TIM?\nUnsaved changes won't be submitted.",
           "modal": true
         }
         const modalOpts: string[] = [
-          'Continue without saving'
+          'Save and Submit',
+          'Submit without Saving',
         ]
         vscode.window.showInformationMessage(
-          'Unsaved Changes in Current File',
+          'There are Unsaved Changes in the Current File',
           messageOpts,
           ...modalOpts
         ).then((answer) => {
-          if (answer === 'Cancel') {
-            return;
+          if (answer === 'Save and Submit') {
+            // Lets save the file
+            
+            const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
+            Tide.submitTask(taskPath, callback) 
+          }
+          else if (answer === 'Submit without Saving') {
+            // TODO: callback should maybe be a show output function
+            const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
+            Tide.submitTask(taskPath, callback)
+          }
+          else {
+            console.log("cancel")
           }
         })
       }
       
-      // TODO: callback should maybe be a show output function
-      const callback = () => vscode.window.showInformationMessage('Task submitted successfully');
-      Tide.submitTask(taskPath, callback) 
     }),
   )
 


### PR DESCRIPTION
This pull request introduces a save dialogue when submitting a task and there are unsaved changes in the file. The save dialog is opened as modal and has options to save and submit, submit without saving, and cancel. 

This pull request changes the message when submitting to not always imply that submission was successful. And in conjunction with this change, also the actual result of the submit is displayed to user by Logger.info visibility from TIM results.

