### PR TITLE
TTV-61 unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@tsconfig/svelte": "^5.0.4",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "22.x",
+				"@types/sinon": "^17.0.4",
 				"@types/vscode": "^1.97.0",
 				"@typescript-eslint/eslint-plugin": "^8.23.0",
 				"@typescript-eslint/parser": "^8.23.0",
@@ -26,6 +27,7 @@
 				"rollup": "^4.34.5",
 				"rollup-plugin-postcss": "^4.0.2",
 				"rollup-plugin-svelte": "^7.2.2",
+				"sinon": "^20.0.0",
 				"svelte": "^5.19.9",
 				"svelte-preprocess": "^6.0.3",
 				"tslib": "^2.5.0",
@@ -817,6 +819,48 @@
 				"win32"
 			]
 		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@sinonjs/samsam": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+			"integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1",
+				"lodash.get": "^4.4.2",
+				"type-detect": "^4.1.0"
+			}
+		},
+		"node_modules/@sinonjs/samsam/node_modules/type-detect": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@trysound/sax": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -876,6 +920,23 @@
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/sinon": {
+			"version": "17.0.4",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+			"integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/sinonjs__fake-timers": "*"
+			}
+		},
+		"node_modules/@types/sinonjs__fake-timers": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+			"integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3196,6 +3257,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5016,6 +5085,47 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/sinon": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+			"integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1",
+				"@sinonjs/fake-timers": "^13.0.5",
+				"@sinonjs/samsam": "^8.0.1",
+				"diff": "^7.0.0",
+				"supports-color": "^7.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/sinon"
+			}
+		},
+		"node_modules/sinon/node_modules/diff": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/sinon/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/smob": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -5518,6 +5628,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -215,9 +215,9 @@
 		"watch": "tsc -watch -p .",
 		"svelte-watch": "rollup -c -w --bundleConfigAsCjs",
 		"svelte-compile": "rollup -c --bundleConfigAsCjs",
-		"pretest": "npm run compile && npm run lint",
+		"_pretest": "npm run compile && npm run lint",
 		"lint": "eslint src --ext ts",
-		"test": "vscode-test"
+		"test": "npm run compile && vscode-test"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^28.0.2",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
 		"@tsconfig/svelte": "^5.0.4",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "22.x",
+		"@types/sinon": "^17.0.4",
 		"@types/vscode": "^1.97.0",
 		"@typescript-eslint/eslint-plugin": "^8.23.0",
 		"@typescript-eslint/parser": "^8.23.0",
@@ -238,9 +239,10 @@
 		"rollup": "^4.34.5",
 		"rollup-plugin-postcss": "^4.0.2",
 		"rollup-plugin-svelte": "^7.2.2",
+		"sinon": "^20.0.0",
 		"svelte": "^5.19.9",
 		"svelte-preprocess": "^6.0.3",
-		"typescript": "^5.7.3",
-		"tslib": "^2.5.0"
+		"tslib": "^2.5.0",
+		"typescript": "^5.7.3"
 	}
 }

--- a/src/test/ExtensionStateManager.test.ts
+++ b/src/test/ExtensionStateManager.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import ExtensionStateManager from '../api/ExtensionStateManager'
+import { LoginData } from '../common/types'
+import { Course, TaskSet } from '../common/types'
+
+suite('ExtensionStateManager Test Suite', () => 
+{
+    let mockState: Record<string, any> = {}
+
+    /* Creating the fake object to pass to the ExtensionStateManager */
+    const testContext =
+    {
+        globalState: 
+        {
+            update: async (key: string, value: any) => 
+            {
+                mockState[key] = value 
+                return Promise.resolve()
+            },
+            get: (key: string) => mockState[key], 
+            setKeysForSync: (_keys: readonly string[]) => {}
+        }
+    } as unknown as vscode.ExtensionContext
+
+    setup(() => 
+    {
+        mockState = {} // clearing mockState before each test 
+        ExtensionStateManager.setContext(testContext) // setting up the fake object 
+    })
+
+    test('setLoginData and getLoginData should store and retrieve the same data', async () => 
+    {
+        const testLoginData: LoginData = 
+        {
+            isLogged: true
+        }
+        ExtensionStateManager.setLoginData(testLoginData) // testing the set method
+        const expectedLoginData = ExtensionStateManager.getLoginData() // testing the get method
+        assert.deepStrictEqual(testLoginData, expectedLoginData, 'Login data should match the stored value')
+    })
+    test('setCourses and getCourses should store and retrieve the same courses', async () => 
+    {
+        const testTaskSets: TaskSet[] = 
+        [
+            {
+                doc_id: 1,
+                name: 'Task Set 1',
+                path: 'path/to/taskset1',
+                downloadPath: 'path/to/download1',
+                tasks: [
+                    { doc_id: 101, ide_task_id: 'task1', path: 'path/to/task1', deadline: '2025-10-01', answer_limit: null },
+                    { doc_id: 102, ide_task_id: 'task2', path: 'path/to/task2', deadline: '2025-10-01', answer_limit: 3 }
+                ]
+            },
+            {
+                doc_id: 2,
+                name: 'Task Set 2',
+                path: 'path/to/taskset2',
+                downloadPath: 'path/to/download2',
+                tasks: [
+                    { doc_id: 201, ide_task_id: 'task3', path: 'path/to/task3', deadline: null, answer_limit: null },
+                    { doc_id: 202, ide_task_id: 'task4', path: 'path/to/task4', deadline: null, answer_limit: null }
+                ]
+            }
+        ]
+
+        const testCourses: Course[] = 
+        [
+            {
+                id: 1,
+                name: 'Course 1',
+                path: 'path/to/course1',
+                taskSets: testTaskSets,
+                status: 'active'
+            },
+            {
+                id: 2,
+                name: 'Course 2',
+                path: 'path/to/course2',
+                taskSets: [],
+                status: 'hidden'
+            }
+        ]
+
+        ExtensionStateManager.setCourses(testCourses) // testing the set method
+        const expectedCourses = ExtensionStateManager.getCourses() // testing the get method
+        assert.deepStrictEqual(testCourses, expectedCourses, 'Courses should match the stored value')
+    })
+})

--- a/src/test/tide.test.ts
+++ b/src/test/tide.test.ts
@@ -22,7 +22,7 @@ describe('Tide', () =>
         ({
             get: sinon.stub().returns('testPath')
         })     
-        // Mocking runAndHandle to return a resolved promise with "mock data"
+        // Arrange: Mocking runAndHandle to return a resolved promise with "mock data"
         const runStub = sinon.stub(Tide as any, "runAndHandle").returns(new Promise((resolve) => resolve("mock data")))
         // Act
         await Tide.downloadTaskSet("Ohjelmointi", "test/path")
@@ -30,4 +30,20 @@ describe('Tide', () =>
         assert.strictEqual(runStub.calledOnce, true, "runAndHandle should be called once")
         sinon.assert.calledWith(runStub, sinon.match.array.startsWith(['task', 'create', 'test/path', '-a', '-d']))
     })  
+    test("login should call runAndHandle and login successfully", async () => 
+    {
+        // Arrange: Mock runAndHandle to simulate a successful login response
+        const runStub = sinon.stub(Tide as any, "runAndHandle").callsFake(async (...args: unknown[]): Promise<void> => 
+        {
+            const callback = args[1] as (data: string) => void;
+            callback(JSON.stringify({ login_success: true }));
+        })
+        // Act: 
+        const result = await Tide.login();
+
+        // Assert: 
+        assert.strictEqual(runStub.calledOnce, true, "runAndHandle should be called once");
+        sinon.assert.calledWith(runStub, sinon.match.array.startsWith(['login', '--json']));
+        assert.deepStrictEqual(result, { isLogged: true }, "The login result should match the expected response");
+    });
 })

--- a/src/test/tide.test.ts
+++ b/src/test/tide.test.ts
@@ -1,0 +1,33 @@
+
+import assert from 'assert'
+import * as vscode from 'vscode'
+import sinon from 'sinon'
+import { describe, test, afterEach } from 'mocha'
+
+import Tide from '../api/tide'
+
+describe('Tide', () => 
+{
+    afterEach(() =>
+    {
+        sinon.restore()
+    })
+
+    test("downloadTaskSet should call runAndHandle", async () =>
+    {
+        // Mocking for TIM-IDE.fileDownloadPath, doesn't matter what it returns as long as it is not undefined
+        let getConfigurationStub: sinon.SinonStub
+        getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration')
+        getConfigurationStub.returns
+        ({
+            get: sinon.stub().returns('testPath')
+        })     
+        // Mocking runAndHandle to return a resolved promise with "mock data"
+        const runStub = sinon.stub(Tide as any, "runAndHandle").returns(new Promise((resolve) => resolve("mock data")))
+        // Act
+        await Tide.downloadTaskSet("Ohjelmointi", "test/path")
+        // Assert
+        assert.strictEqual(runStub.calledOnce, true, "runAndHandle should be called once")
+        sinon.assert.calledWith(runStub, sinon.match.array.startsWith(['task', 'create', 'test/path', '-a', '-d']))
+    })  
+})


### PR DESCRIPTION
Fixed deprecated tests for  ExtensionStateManager and added tests for Tide.ts 

Added libraries: sinon used for mocking. Command pretest in package.json "commented out" because it requires linting and there is no decision yet about that.

Tests can be run with command "npm run test" which compiles the files and runs vscode-test





