### PR TITLE
Remove value logger

### DIFF
--- a/src/api/ExtensionStateManager.ts
+++ b/src/api/ExtensionStateManager.ts
@@ -306,7 +306,6 @@ export default class ExtensionStateManager {
   private static readFromGlobalState(key: StateKey): any {
     const prefixedKey = this.prefixedKey(key)
     const value: any = this.globalState.get(prefixedKey)
-    Logger.debug(`Found the following value from key "${prefixedKey}"`, value)
     return value
   }
 


### PR DESCRIPTION
Remove value logger, that dominates debug output and makes reading other, more valuable information hard.