### PR TITLE
Ttv 216 restore submit information message

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -223,8 +223,10 @@ export default class Tide {
    */
   public static async submitTask(taskPath: string, callback: () => any) {
     try {
+      Logger.info("The current task is being submitted to TIM. Please wait for the TIM response.")
       this.runAndHandle(['submit', taskPath], (data: string) => {
         Logger.info(data)
+        callback()
         const downloadPath = Formatting.normalizePath(path.dirname(path.dirname(taskPath)))
         const course: Course =  ExtensionStateManager.getCourseByDownloadPath(downloadPath)
         const taskset = course.taskSets.find(taskSet => taskSet.downloadPath === downloadPath)


### PR DESCRIPTION
This pull request restores the information message that pops up when submitting to TIM.

Also uses Logger to display a text to the user that indicates that the submit process has started. This is useful because usually getting feedback from TIM takes time, and the user needs immediate feedback from the pressing of the submit icon.