### PR TITLE
fix disappearing information from taskpanel when minimizing it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   // Creates and registers the taskpanel menu on the left
   const taskPanelProvider = new TaskPanelProvider(ctx.extensionUri)
-  ctx.subscriptions.push(vscode.window.registerWebviewViewProvider('tide-taskpanel', taskPanelProvider))
+  const webviewViewopts = {
+    webviewOptions: {
+      retainContextWhenHidden : true
+    }
+  }
+  ctx.subscriptions.push(vscode.window.registerWebviewViewProvider('tide-taskpanel', taskPanelProvider, webviewViewopts))
 
   // Creates and registers taskbar item for displaying answer_limit warnings
   const answerLimitStatusBarItem = new AnswerLimitStatusBarItem(vscode.StatusBarAlignment.Right, 500)


### PR DESCRIPTION
This pull request adds an option "retainContextWhenHidden: true" to the registering of the WebviewViewProvider. It prevents the loss of context when hiding the taskpanel. This can happen for example when minimizing it.