### PR TITLE
TTV-205 fix moving the taskPanel to rightside panel

### DIFF
--- a/src/ui/panels/TaskPanelProvider.ts
+++ b/src/ui/panels/TaskPanelProvider.ts
@@ -53,9 +53,19 @@ export class TaskPanelProvider implements vscode.WebviewViewProvider {
         this.sendLoginData();
         this.sendCustomUrl();
 
-        vscode.commands.registerCommand('tide.setPointsUpdating', () => {
-            this.setPointsUpdating();
-        });
+        // Check if the command has already been registered
+        vscode.commands.getCommands(true).then(
+            (registeredCommands: string[]) => {
+                if (!registeredCommands.includes('tide.setPointsUpdating')) {
+                    vscode.commands.registerCommand('tide.setPointsUpdating', () => {
+                        this.setPointsUpdating();
+                    });
+                }
+            },
+            (err) => {
+                vscode.window.showErrorMessage('Could not get registered command:', err)
+            }
+        )
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the bug that caused an error when moving the taskPanel to the secondary sidebar.

The faulty behavior was caused by registering a command in resolveWebviewView. When taskPanel was moved another attempt to register the same command was made, resulting in an error. In this pull request it is fixed by checking whether the command is already in the list of commands.