### PR TITLE
change the environmental variable URL to TIM_URL

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -311,10 +311,10 @@ export default class Tide {
     if (customUrl && customUrl.trim() !== "") {
       // Ensure that the custom url ends with a slash
       const formattedUrl = customUrl.trim().endsWith("/") ? customUrl.trim() : customUrl.trim() + "/"
-      env_modified.URL = formattedUrl
+      env_modified.TIM_URL = formattedUrl
     }
     else {
-      env_modified.URL = "https://tim.jyu.fi/"
+      env_modified.TIM_URL = "https://tim.jyu.fi/"
     }
 
     // To run an uncompiled version of the CLI tool:


### PR DESCRIPTION
This pull request changes the environmental variable URL in tide.ts to TIM_URL, in order to match variable name in the current version of the TIDE-CLI.