### PR TITLE
Catch task metadata updated message and print it to logger

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -159,7 +159,12 @@ export default class Tide {
       }
       await this.runAndHandle(['task', 'create', taskSetPath, '-a', '-d', localCoursePath, '-j'], (data: string) => {
         Logger.debug(data)
-        const tasks = JSON.parse(data)
+        let cleanData = data.trimStart()
+        if (cleanData.startsWith('Task metadata updated')) {
+          Logger.info('Task metadata has been updated.')
+          cleanData = cleanData.substring(cleanData.indexOf('['))
+        }
+        const tasks = JSON.parse(cleanData)
         ExtensionStateManager.setTaskSetPaths(localTaskPath, taskSetPath, tasks)
       })
     }


### PR DESCRIPTION
Fix: Handle "Task metadata updated" message from TIDE-CLI

If a task is modified In TIM after download and a re-download is attempted, TIDE-CLI may return the message "Task metadata updated" before the actual JSON payload. This caused a JSON parsing error.

This PR adds a check to detect and strip this message before parsing the response, ensuring the extension can handle the output correctly.