### PR TITLE
Ttv 219 taskpanel h3 color to grey

### DIFF
--- a/webviews/components/taskPanel/TaskPanel.svelte
+++ b/webviews/components/taskPanel/TaskPanel.svelte
@@ -199,6 +199,7 @@ This component manages the display of task information and interaction with task
   .task-panel h3 {
     margin: 0;
     font-weight: bold;
+    color:#bcbcbcbc;
   }
 
   .task-panel p {
@@ -215,7 +216,7 @@ This component manages the display of task information and interaction with task
     margin-top: 10px;
     margin-bottom: 10px;
     border: none;
-    border-top: 1px inset #ccc;
+    border-top: 1px inset #bcbcbcbc;
     width: 100%;
   }
 


### PR DESCRIPTION
Updated the <h3> elements in the TaskPanel to use a grey color to reduce contrast and improve readability.

Modified the <hr> line color to match the new header style for improved visual consistency.